### PR TITLE
Bump package.json version to 0.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubevirt-ui/vnc-keymaps",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "type": "module",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"


### PR DESCRIPTION
Release 0.0.2 failed to build. Since immutable releases are configured it's no longer possible to use 0.0.2 version/tag for a new release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.0.3

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->