### PR TITLE
Configure trusted publishing for npm    

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -31,17 +31,18 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v5
-      #change the organization for npm
-      - run: sed -i -E 's/@kubevirt-ui/@kubevirt-ui-ext/' package.json
+      - name: Change the organization for npm to @kubevirt-ui-ext
+        run: jq '.name |= sub("@kubevirt-ui/";"@kubevirt-ui-ext/")' package.json > tmp.json && mv tmp.json package.json
       - uses: actions/setup-node@v6
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
           scope: '@kubevirt-ui-ext'
+        # Ensure npm 11.5.1 or later is installed
+      - name: Update npm for Trusted Publishing
+        run: npm install -g npm@latest
       - run: |
           npm version
           npm clean-install --verbose --ignore-scripts --no-audit
       - run: npm run build
       - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_FOR_KUBEVIRT_UI_EXT }}

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@kubevirt-ui/vnc-keymaps",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "type": "module",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"
   },
-  "description": "Keymps for VNC",
+  "description": "Keymaps for VNC",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -39,7 +39,7 @@
   "packageManager": "npm@10.9.4",
   "engines": {
     "npm": ">=10.9.4",
-    "node": ">=22.21.1"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "npm run test && tsup",


### PR DESCRIPTION
1. Lower minimum Node version to 22.0.0. Test runners used for e2e      
   tests are currently running 22.14.0                                  
2. Bump version to 1.0.4.                                               
3. use jq instead of sed to modify package.json before npm publish      
                                                                        
Reference-Url: https://docs.npmjs.com/trusted-publishers                
Reference-Url: https://github.com/kubevirt-ui/kubevirt-plugin/pull/3250 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a typo in the product description.

* **Chores**
  * Released v1.0.4.
  * Lowered the minimum Node.js requirement to >=22.0.0.
  * Updated the publishing workflow to set the package scope/org and to install the latest npm before publishing; adjusted the publishing authentication flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->