### PR TITLE
downgrade npm restriction for runner issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "packageManager": "npm@10.9.4",
   "engines": {
-    "npm": ">=10.9.4",
+    "npm": ">=10.9.0",
     "node": ">=22.0.0"
   },
   "scripts": {


### PR DESCRIPTION
e2e prow runner have npm `10.9.2` version. So downgrading to make sure we don't get any warning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated npm engine requirement to support npm version 10.9.0 or later.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->